### PR TITLE
Bump upstream and update stemcell

### DIFF
--- a/aws/cpi.yml
+++ b/aws/cpi.yml
@@ -7,8 +7,8 @@
 - path: /resource_pools/name=vms/stemcell?
   type: replace
   value:
-    sha1: 803b8bcbd895fbfa040fa0fcfeb1a11225678f71
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=250.4
+    sha1: 105c85655bbabdaef59bffe7d6956c026fc0a4aa
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=250.9
 - path: /resource_pools/name=vms/cloud_properties?
   type: replace
   value:

--- a/aws/cpi.yml
+++ b/aws/cpi.yml
@@ -7,8 +7,8 @@
 - path: /resource_pools/name=vms/stemcell?
   type: replace
   value:
-    sha1: 33583a46ecc3eaa9f3be2a0187817a9b06367e36
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=170.25
+    sha1: 803b8bcbd895fbfa040fa0fcfeb1a11225678f71
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=250.4
 - path: /resource_pools/name=vms/cloud_properties?
   type: replace
   value:

--- a/aws/cpi.yml
+++ b/aws/cpi.yml
@@ -7,8 +7,8 @@
 - path: /resource_pools/name=vms/stemcell?
   type: replace
   value:
-    sha1: 803b8bcbd895fbfa040fa0fcfeb1a11225678f71
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=250.4
+    sha1: 33583a46ecc3eaa9f3be2a0187817a9b06367e36
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=170.25
 - path: /resource_pools/name=vms/cloud_properties?
   type: replace
   value:

--- a/cloudstack/cpi.yml
+++ b/cloudstack/cpi.yml
@@ -9,8 +9,8 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell?
   value:
-    url: https://github.com/orange-cloudfoundry/bosh-linux-stemcell-builder/releases/download/v3586.26/bosh-stemcell-3586.26-cloudstack-xen-ubuntu-trusty-go_agent.tgz
-    sha1: 07eefba3b194554a3030d17e672222ac93a84367
+    url: https://github.com/orange-cloudfoundry/bosh-linux-stemcell-builder/releases/download/ubuntu-xenial%2Fv250.4/bosh-stemcell-250.4-cloudstack-xen-ubuntu-xenial-go_agent.tgz
+    sha1: 824c668bfd9feb79c2b03f9389807b55186f3206
 
 - type: replace
   path: /resource_pools/name=vms/cloud_properties?

--- a/gcp/cpi.yml
+++ b/gcp/cpi.yml
@@ -7,8 +7,8 @@
 - path: /resource_pools/name=vms/stemcell?
   type: replace
   value:
-    sha1: b9498e64d1c812dc49328ce27d4e896dda3b2372
-    url: https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-xenial-go_agent?v=250.4
+    sha1: 30e23a961d14d0aee7d71c15eca392170f049fbf
+    url: https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-xenial-go_agent?v=250.9
 - path: /resource_pools/name=vms/cloud_properties?
   type: replace
   value:

--- a/gcp/cpi.yml
+++ b/gcp/cpi.yml
@@ -2,8 +2,8 @@
   type: replace
   value:
     name: bosh-google-cpi
-    sha1: 911a48764dbb24c50aedd4e3095d1603d385e135
-    url: https://bosh.io/d/github.com/cloudfoundry/bosh-google-cpi-release?v=27.0.1
+    sha1: aba0451b5be65d8bbf3cf7f289c5432192892284
+    url: https://bosh.io/d/github.com/cloudfoundry/bosh-google-cpi-release?v=29.0.1
 - path: /resource_pools/name=vms/stemcell?
   type: replace
   value:

--- a/gcp/cpi.yml
+++ b/gcp/cpi.yml
@@ -7,8 +7,8 @@
 - path: /resource_pools/name=vms/stemcell?
   type: replace
   value:
-    sha1: b9498e64d1c812dc49328ce27d4e896dda3b2372
-    url: https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-xenial-go_agent?v=250.4
+    sha1: f03d6263803ae88a50cbb54f2797207b0ea0d14a
+    url: https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-xenial-go_agent?v=170.25
 - path: /resource_pools/name=vms/cloud_properties?
   type: replace
   value:

--- a/gcp/cpi.yml
+++ b/gcp/cpi.yml
@@ -7,8 +7,8 @@
 - path: /resource_pools/name=vms/stemcell?
   type: replace
   value:
-    sha1: f03d6263803ae88a50cbb54f2797207b0ea0d14a
-    url: https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-xenial-go_agent?v=170.25
+    sha1: b9498e64d1c812dc49328ce27d4e896dda3b2372
+    url: https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-xenial-go_agent?v=250.4
 - path: /resource_pools/name=vms/cloud_properties?
   type: replace
   value:

--- a/jumpbox.yml
+++ b/jumpbox.yml
@@ -13,6 +13,8 @@ resource_pools:
   env:
     bosh:
       password: "*"
+      mbus:
+        cert: ((mbus_bootstrap_ssl))
 
 networks:
 - name: private
@@ -48,6 +50,7 @@ instance_groups:
 
 cloud_provider:
   mbus: https://mbus:((mbus_bootstrap_password))@((external_ip)):6868
+  cert: ((mbus_bootstrap_ssl))
   properties:
     agent: {mbus: "https://mbus:((mbus_bootstrap_password))@0.0.0.0:6868"}
     blobstore: {provider: local, path: /var/vcap/micro_bosh/data/cache}
@@ -62,3 +65,16 @@ variables:
   type: password
 - name: jumpbox_ssh
   type: ssh
+
+- name: default_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: ca
+
+- name: mbus_bootstrap_ssl
+  type: certificate
+  options:
+    ca: default_ca
+    common_name: ((external_ip))
+    alternative_names: [((external_ip))]

--- a/jumpbox.yml
+++ b/jumpbox.yml
@@ -63,6 +63,7 @@ cloud_provider:
 variables:
 - name: mbus_bootstrap_password
   type: password
+
 - name: jumpbox_ssh
   type: ssh
 

--- a/no-external-ip.yml
+++ b/no-external-ip.yml
@@ -4,3 +4,10 @@
 - type: replace
   path: /cloud_provider/mbus
   value: https://mbus:((mbus_bootstrap_password))@((internal_ip)):6868
+
+- type: replace
+  path: /variables/name=mbus_bootstrap_ssl/options
+  value:
+    ca: default_ca
+    common_name: ((internal_ip))
+    alternative_names: [((internal_ip))]

--- a/openstack/cpi.yml
+++ b/openstack/cpi.yml
@@ -7,8 +7,8 @@
 - path: /resource_pools/name=vms/stemcell?
   type: replace
   value:
-    sha1: 7d8976cdbc95dcc339df284144a222aaa5841de2
-    url: https://bosh.io/d/stemcells/bosh-openstack-kvm-ubuntu-xenial-go_agent?v=250.4
+    sha1: 7f3db7c4aab94df8410ff91d4e1b0fb11c741eaf
+    url: https://bosh.io/d/stemcells/bosh-openstack-kvm-ubuntu-xenial-go_agent?v=170.25
 - path: /resource_pools/name=vms/cloud_properties?
   type: replace
   value:

--- a/openstack/cpi.yml
+++ b/openstack/cpi.yml
@@ -7,8 +7,8 @@
 - path: /resource_pools/name=vms/stemcell?
   type: replace
   value:
-    sha1: 7f3db7c4aab94df8410ff91d4e1b0fb11c741eaf
-    url: https://bosh.io/d/stemcells/bosh-openstack-kvm-ubuntu-xenial-go_agent?v=170.25
+    sha1: 7d8976cdbc95dcc339df284144a222aaa5841de2
+    url: https://bosh.io/d/stemcells/bosh-openstack-kvm-ubuntu-xenial-go_agent?v=250.4
 - path: /resource_pools/name=vms/cloud_properties?
   type: replace
   value:

--- a/openstack/cpi.yml
+++ b/openstack/cpi.yml
@@ -7,8 +7,8 @@
 - path: /resource_pools/name=vms/stemcell?
   type: replace
   value:
-    sha1: 7d8976cdbc95dcc339df284144a222aaa5841de2
-    url: https://bosh.io/d/stemcells/bosh-openstack-kvm-ubuntu-xenial-go_agent?v=250.4
+    sha1: b6734ea52693d7b558b82732f239d0a1206f94df
+    url: https://bosh.io/d/stemcells/bosh-openstack-kvm-ubuntu-xenial-go_agent?v=250.9
 - path: /resource_pools/name=vms/cloud_properties?
   type: replace
   value:

--- a/vsphere/cpi.yml
+++ b/vsphere/cpi.yml
@@ -7,8 +7,8 @@
 - path: /resource_pools/name=vms/stemcell?
   type: replace
   value:
-    sha1: 65d5e5923cb0ec54bb94e2824612df03e2e278f5
-    url: https://bosh.io/d/stemcells/bosh-vsphere-esxi-ubuntu-xenial-go_agent?v=250.4
+    sha1: 9bf64ac83cdbc233c16f149985811b0a2d72178b
+    url: https://bosh.io/d/stemcells/bosh-vsphere-esxi-ubuntu-xenial-go_agent?v=170.25
 - path: /resource_pools/name=vms/cloud_properties?
   type: replace
   value:

--- a/vsphere/cpi.yml
+++ b/vsphere/cpi.yml
@@ -7,8 +7,8 @@
 - path: /resource_pools/name=vms/stemcell?
   type: replace
   value:
-    sha1: 65d5e5923cb0ec54bb94e2824612df03e2e278f5
-    url: https://bosh.io/d/stemcells/bosh-vsphere-esxi-ubuntu-xenial-go_agent?v=250.4
+    sha1: ec327636a44ff3247ed87729d45d17a90a8fabb4
+    url: https://bosh.io/d/stemcells/bosh-vsphere-esxi-ubuntu-xenial-go_agent?v=250.9
 - path: /resource_pools/name=vms/cloud_properties?
   type: replace
   value:

--- a/vsphere/cpi.yml
+++ b/vsphere/cpi.yml
@@ -7,8 +7,8 @@
 - path: /resource_pools/name=vms/stemcell?
   type: replace
   value:
-    sha1: 9bf64ac83cdbc233c16f149985811b0a2d72178b
-    url: https://bosh.io/d/stemcells/bosh-vsphere-esxi-ubuntu-xenial-go_agent?v=170.25
+    sha1: 65d5e5923cb0ec54bb94e2824612df03e2e278f5
+    url: https://bosh.io/d/stemcells/bosh-vsphere-esxi-ubuntu-xenial-go_agent?v=250.4
 - path: /resource_pools/name=vms/cloud_properties?
   type: replace
   value:


### PR DESCRIPTION
update from upstream is required in order to be compatible with new versions of [bosh-agent](https://github.com/cloudfoundry/bosh-agent/commit/ae66e2dbb2ecddd4805d2b29a49de220671b8166#diff-fdb8759aa7ef1b3e16b74fee25acd4fb)